### PR TITLE
Catch any kind of exception from reflection calls

### DIFF
--- a/src/main/java/org/jvnet/hudson/annotation_indexer/Index.java
+++ b/src/main/java/org/jvnet/hudson/annotation_indexer/Index.java
@@ -107,6 +107,8 @@ public class Index {
                                 LOGGER.log(Level.FINE, "Failed to load: "+name,e);
                             } catch (LinkageError x) {
                                 LOGGER.log(Level.WARNING, "Failed to load " + name, x);
+                            } catch (RuntimeException x) {
+                                LOGGER.log(Level.WARNING, "Failed to load " + name, x);
                             }
                         }
                     }


### PR DESCRIPTION
Works around a bug in the JRE which I just submitted (internal review ID : 9049673; will update with OpenJDK permalink once I have one). The symptom can be seen by running `org.jenkinsci.plugins.credentialsbinding.impl.CertificateMultiBindingTest#basicsPipeline` as of `credentials-binding-1.12` (i.e., using an old parent POM and thus predating https://github.com/jenkinsci/jenkins-test-harness/pull/35) against a `workflow-cps` updated to 2.36. Without this patch, the test fails with a cryptic exception; with it, a warning is printed but the test succeeds:

```
… org.jvnet.hudson.annotation_indexer.Index$2$1 fetch
WARNING: Failed to load org.jenkinsci.plugins.workflow.cps.DSLTest$Pojo$DescriptorImpl
java.lang.NullPointerException
	at sun.reflect.annotation.AnnotationParser.parseArray(AnnotationParser.java:532)
	at sun.reflect.annotation.AnnotationParser.parseMemberValue(AnnotationParser.java:355)
	at sun.reflect.annotation.AnnotationParser.parseAnnotation2(AnnotationParser.java:286)
	at sun.reflect.annotation.AnnotationParser.parseAnnotations2(AnnotationParser.java:120)
	at sun.reflect.annotation.AnnotationParser.parseAnnotations(AnnotationParser.java:72)
	at java.lang.Class.createAnnotationData(Class.java:3521)
	at java.lang.Class.annotationData(Class.java:3510)
	at java.lang.Class.getAnnotation(Class.java:3415)
	at java.lang.reflect.AnnotatedElement.isAnnotationPresent(AnnotatedElement.java:258)
	at java.lang.Class.isAnnotationPresent(Class.java:3425)
	at org.jvnet.hudson.annotation_indexer.Index$2$1.fetch(Index.java:101)
	at org.jvnet.hudson.annotation_indexer.Index$2$1.hasNext(Index.java:73)
	at org.jvnet.hudson.annotation_indexer.SubtypeIterator.fetch(SubtypeIterator.java:18)
	at org.jvnet.hudson.annotation_indexer.SubtypeIterator.hasNext(SubtypeIterator.java:28)
	at org.jenkinsci.plugins.structs.SymbolLookup.findDescriptor(SymbolLookup.java:95)
	at org.jenkinsci.plugins.workflow.steps.StepDescriptor.metaStepsOf(StepDescriptor.java:303)
	at org.jenkinsci.plugins.workflow.cps.DSL.invokeDescribable(DSL.java:279)
	at org.jenkinsci.plugins.workflow.cps.DSL.invokeMethod(DSL.java:153)
	at org.jenkinsci.plugins.workflow.cps.CpsScript.invokeMethod(CpsScript.java:108)
	at …
```

@reviewbybees