### PR TITLE
Fix build and test on Java 10+.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,11 @@
     Creates index of annotations.
   </description>
 
+  <properties>
+    <java.level>8</java.level>
+    <java.level.test>8</java.level.test>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.kohsuke.metainf-services</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.37</version>
+    <version>1.46</version>
     <relativePath />
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>org.kohsuke.metainf-services</groupId>
       <artifactId>metainf-services</artifactId>
-      <version>1.7</version>
+      <version>1.8</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/src/main/java/org/jvnet/hudson/annotation_indexer/Index.java
+++ b/src/main/java/org/jvnet/hudson/annotation_indexer/Index.java
@@ -45,14 +45,13 @@ public class Index {
         final Enumeration<URL> res = cl.getResources("META-INF/annotations/"+type.getName());
         while (res.hasMoreElements()) {
             URL url = res.nextElement();
-            InputStream is = url.openStream();
-            try (BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"))) {
+
+            try (InputStream is = url.openStream();
+                 BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"))) {
                 String line;
                 while ((line = r.readLine()) != null) {
                     ids.add(line);
                 }
-            } finally {
-                is.close();
             }
         }
 

--- a/src/main/java/org/jvnet/hudson/annotation_indexer/Index.java
+++ b/src/main/java/org/jvnet/hudson/annotation_indexer/Index.java
@@ -46,13 +46,17 @@ public class Index {
         while (res.hasMoreElements()) {
             URL url = res.nextElement();
             InputStream is = url.openStream();
+            BufferedReader r = null;
             try {
-                BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+                r = new BufferedReader(new InputStreamReader(is, "UTF-8"));
                 String line;
                 while ((line = r.readLine()) != null) {
                     ids.add(line);
                 }
             } finally {
+                if (r != null) {
+                    r.close();
+                }
                 is.close();
             }
         }

--- a/src/main/java/org/jvnet/hudson/annotation_indexer/Index.java
+++ b/src/main/java/org/jvnet/hudson/annotation_indexer/Index.java
@@ -46,17 +46,12 @@ public class Index {
         while (res.hasMoreElements()) {
             URL url = res.nextElement();
             InputStream is = url.openStream();
-            BufferedReader r = null;
-            try {
-                r = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+            try (BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"))) {
                 String line;
                 while ((line = r.readLine()) != null) {
                     ids.add(line);
                 }
             } finally {
-                if (r != null) {
-                    r.close();
-                }
                 is.close();
             }
         }

--- a/src/test/java/org/jvnet/hudson/annotation_indexer/AnnotationProcessorImplTest.java
+++ b/src/test/java/org/jvnet/hudson/annotation_indexer/AnnotationProcessorImplTest.java
@@ -26,7 +26,7 @@ public class AnnotationProcessorImplTest {
         compilation.addSource("some.pkg.Stuff").
                 addLine("package some.pkg;").
                 addLine("@some.api.A public class Stuff {}");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8");
         assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
         assertEquals("some.pkg.Stuff" + System.getProperty("line.separator"), Utils.getGeneratedResource(compilation, "META-INF/annotations/some.api.A"));
     }
@@ -37,7 +37,7 @@ public class AnnotationProcessorImplTest {
         compilation.addSource("some.pkg.Stuff").
                 addLine("package some.pkg;").
                 addLine("@" + A.class.getCanonicalName() + " public class Stuff {}");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8");
         assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
         assertEquals("some.pkg.Stuff" + System.getProperty("line.separator"), Utils.getGeneratedResource(compilation, "META-INF/annotations/" + A.class.getName()));
     }
@@ -47,14 +47,14 @@ public class AnnotationProcessorImplTest {
         compilation.addSource("some.pkg.Stuff").
                 addLine("package some.pkg;").
                 addLine("@" + A.class.getCanonicalName() + " public class Stuff {}");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8");
         assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
         assertEquals("some.pkg.Stuff" + System.getProperty("line.separator"), Utils.getGeneratedResource(compilation, "META-INF/annotations/" + A.class.getName()));
         compilation = new Compilation(compilation);
         compilation.addSource("some.pkg.MoreStuff").
                 addLine("package some.pkg;").
                 addLine("@" + A.class.getCanonicalName() + " public class MoreStuff {}");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8");
         assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
         assertEquals("some.pkg.MoreStuff" + System.getProperty("line.separator") + "some.pkg.Stuff" + System.getProperty("line.separator"), Utils.getGeneratedResource(compilation, "META-INF/annotations/" + A.class.getName()));
     }
@@ -66,7 +66,7 @@ public class AnnotationProcessorImplTest {
         compilation.addSource("some.pkg.Stuff").
                 addLine("package some.pkg;").
                 addLine("public class Stuff extends " + Super.class.getCanonicalName() + " {}");
-        compilation.doCompile(null, "-source", "6");
+        compilation.doCompile(null, "-source", "8");
         assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
         /* XXX #7188605 currently broken on JDK 6; perhaps need to use a ElementScanner6 on roundEnv.rootElements whose visitType checks for annotations
         assertEquals("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, "META-INF/annotations/" + B.class.getName()));

--- a/src/test/java/org/jvnet/hudson/annotation_indexer/Utils.java
+++ b/src/test/java/org/jvnet/hudson/annotation_indexer/Utils.java
@@ -24,8 +24,7 @@ class Utils {
     // Filter out warnings about source 1.6 is obsolete in java 9
     // This usually appears with other warnings
     public static final List<String> IGNORE = Arrays.asList(
-            "source value 1.6 is obsolete and will be removed in a future release", // Filter out warnings about source 1.6 is obsolete in java 9
-            "To suppress warnings about obsolete options" // This usually appears with other warnings
+            "RELEASE_6" // Filter out warnings about source 1.6 is obsolete in java 9+
     );
 
     public static List<Diagnostic<? extends JavaFileObject>> filterObsoleteSourceVersionWarnings(List<Diagnostic<? extends JavaFileObject>> diagnostics) {


### PR DESCRIPTION
Fix the project so that it successfully builds and completes tests with Java 10+ and with current dependencies.
In the tests, move the source target forward to something still supported. Simplify the existing IGNORE list to handle the annotation processor failure within hickory with a single check that works for Java 9, 10, and 11 and is unlikely to change for future Java releases.
Update to a latest version of the parent pom to keep things current.
With the latest pom, it now runs findbugs. Fix the findbugs warning. For Java 9+ we will need to switch from findbugs to spotbugs to get it working fully, but that change is for a different PR. It should start in the parent pom.

Locally I have built with this change on Java 8, 9, 10, and 11ea. On each of those versions it compiles and all tests and checks pass.