### PR TITLE
Change the location where the index gets written

### DIFF
--- a/src/main/java/org/jvnet/hudson/annotation_indexer/AnnotationProcessorImpl.java
+++ b/src/main/java/org/jvnet/hudson/annotation_indexer/AnnotationProcessorImpl.java
@@ -93,7 +93,7 @@ public class AnnotationProcessorImpl extends AbstractProcessor {
         }
 
         String getIndexFileName() {
-            return "META-INF/annotations/" + annotationName;
+            return "META-INF/services/annotations/" + annotationName;
         }
 
         /**

--- a/src/main/java/org/jvnet/hudson/annotation_indexer/Index.java
+++ b/src/main/java/org/jvnet/hudson/annotation_indexer/Index.java
@@ -7,6 +7,7 @@ import java.io.InputStreamReader;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -20,6 +21,14 @@ import java.util.logging.Logger;
  * @author Kohsuke Kawaguchi
  */
 public class Index {
+    /**
+     * Resource path in which we look up the index.
+     *
+     * <p>
+     * Historically we put things under META-INF/annotations.
+     */
+    private static final List<String> PREFIXES = Arrays.asList("META-INF/annotations/", "META-INF/services/annotations/");
+
     /**
      * Lists up all the elements annotated by the given annotation and of the given {@link AnnotatedElement} subtype.
      */
@@ -42,15 +51,17 @@ public class Index {
 
         final Set<String> ids = new TreeSet<String>();
 
-        final Enumeration<URL> res = cl.getResources("META-INF/annotations/"+type.getName());
-        while (res.hasMoreElements()) {
-            URL url = res.nextElement();
+        for (String prefix : PREFIXES) {
+            final Enumeration<URL> res = cl.getResources(prefix + type.getName());
+            while (res.hasMoreElements()) {
+                URL url = res.nextElement();
 
-            try (InputStream is = url.openStream();
-                 BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"))) {
-                String line;
-                while ((line = r.readLine()) != null) {
-                    ids.add(line);
+                try (InputStream is = url.openStream();
+                     BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"))) {
+                    String line;
+                    while ((line = r.readLine()) != null) {
+                        ids.add(line);
+                    }
                 }
             }
         }

--- a/src/test/java/org/jvnet/hudson/annotation_indexer/AnnotationProcessorImplTest.java
+++ b/src/test/java/org/jvnet/hudson/annotation_indexer/AnnotationProcessorImplTest.java
@@ -29,7 +29,7 @@ public class AnnotationProcessorImplTest {
                 addLine("@some.api.A public class Stuff {}");
         compilation.doCompile(null, "-source", "8");
         assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
-        assertEquals("some.pkg.Stuff" + System.getProperty("line.separator"), Utils.getGeneratedResource(compilation, "META-INF/annotations/some.api.A"));
+        assertEquals("some.pkg.Stuff" + System.getProperty("line.separator"), Utils.getGeneratedResource(compilation, "META-INF/services/annotations/some.api.A"));
     }
 
     @Indexed @Retention(RetentionPolicy.RUNTIME) public @interface A {}
@@ -40,7 +40,7 @@ public class AnnotationProcessorImplTest {
                 addLine("@" + A.class.getCanonicalName() + " public class Stuff {}");
         compilation.doCompile(null, "-source", "8");
         assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
-        assertEquals("some.pkg.Stuff" + System.getProperty("line.separator"), Utils.getGeneratedResource(compilation, "META-INF/annotations/" + A.class.getName()));
+        assertEquals("some.pkg.Stuff" + System.getProperty("line.separator"), Utils.getGeneratedResource(compilation, "META-INF/services/annotations/" + A.class.getName()));
     }
 
     @Test public void incremental() {
@@ -50,14 +50,14 @@ public class AnnotationProcessorImplTest {
                 addLine("@" + A.class.getCanonicalName() + " public class Stuff {}");
         compilation.doCompile(null, "-source", "8");
         assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
-        assertEquals("some.pkg.Stuff" + System.getProperty("line.separator"), Utils.getGeneratedResource(compilation, "META-INF/annotations/" + A.class.getName()));
+        assertEquals("some.pkg.Stuff" + System.getProperty("line.separator"), Utils.getGeneratedResource(compilation, "META-INF/services/annotations/" + A.class.getName()));
         compilation = new Compilation(compilation);
         compilation.addSource("some.pkg.MoreStuff").
                 addLine("package some.pkg;").
                 addLine("@" + A.class.getCanonicalName() + " public class MoreStuff {}");
         compilation.doCompile(null, "-source", "8");
         assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
-        assertEquals("some.pkg.MoreStuff" + System.getProperty("line.separator") + "some.pkg.Stuff" + System.getProperty("line.separator"), Utils.getGeneratedResource(compilation, "META-INF/annotations/" + A.class.getName()));
+        assertEquals("some.pkg.MoreStuff" + System.getProperty("line.separator") + "some.pkg.Stuff" + System.getProperty("line.separator"), Utils.getGeneratedResource(compilation, "META-INF/services/annotations/" + A.class.getName()));
     }
 
     @Indexed @Retention(RetentionPolicy.RUNTIME) @Inherited public @interface B {}
@@ -70,7 +70,7 @@ public class AnnotationProcessorImplTest {
         compilation.doCompile(null, "-source", "8");
         assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
         /* XXX #7188605 currently broken on JDK 6; perhaps need to use a ElementScanner6 on roundEnv.rootElements whose visitType checks for annotations
-        assertEquals("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, "META-INF/annotations/" + B.class.getName()));
+        assertEquals("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, "META-INF/services/annotations/" + B.class.getName()));
         */
     }
 


### PR DESCRIPTION
This allows tools like uberjar/fatjar/onejar/etc to merge the entries across multiple jar files successfully, because the content is formatted the same way as service providers.

It's a bit of a hijack of the namespace, but one where I cannot think of any downside.

On the reading side we continue to look for the index written in the old location in order to work well with artifacts built by earlier versions of the library.