### PR TITLE
Do not log `NoClassDefFoundError`s

### DIFF
--- a/src/main/java/org/jvnet/hudson/annotation_indexer/Index.java
+++ b/src/main/java/org/jvnet/hudson/annotation_indexer/Index.java
@@ -133,8 +133,8 @@ public class Index {
                                 listAnnotatedElements(c.getDeclaredMethods());
                                 listAnnotatedElements(c.getDeclaredFields());
                                 listAnnotatedElements(c.getDeclaredConstructors());
-                            } catch (ClassNotFoundException e) {
-                                LOGGER.log(Level.FINE, "Failed to load: "+name,e);
+                            } catch (ClassNotFoundException | NoClassDefFoundError x) {
+                                LOGGER.log(Level.FINE, "Failed to load: " + name, x);
                             } catch (LinkageError | RuntimeException x) {
                                 LOGGER.log(Level.WARNING, "Failed to load " + name, x);
                             }


### PR DESCRIPTION
If you have an `@OptionalExtension` also marked with a `@Symbol` you could otherwise get errors such as

```
WARNING	o.j.h.a.Index$2$1#fetch: Failed to load requiring.optional.dep.SomeDescribable$DescriptorImpl
java.lang.ClassNotFoundException: com.cloudbees.opscenter.server.model.ConnectedMasterPropertyDescriptor
	at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1417)
	at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1372)
	at jenkins.util.AntClassLoader.loadClass(AntClassLoader.java:1127)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
Caused: java.lang.NoClassDefFoundError: from/optional/dep/SomeDescriptorSupertype
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
	at jenkins.util.AntClassLoader.defineClassFromData(AntClassLoader.java:1187)
	at jenkins.util.AntClassLoader.getClassFromStream(AntClassLoader.java:1355)
	at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1407)
	at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1372)
	at jenkins.ClassLoaderReflectionToolkit._findClass(ClassLoaderReflectionToolkit.java:107)
	at hudson.PluginManager$UberClassLoader.findClass(PluginManager.java:2133)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	at org.jvnet.hudson.annotation_indexer.Index$2$1.fetch(Index.java:123)
	at org.jvnet.hudson.annotation_indexer.Index$2$1.hasNext(Index.java:92)
	at org.jvnet.hudson.annotation_indexer.SubtypeIterator.fetch(SubtypeIterator.java:18)
	at org.jvnet.hudson.annotation_indexer.SubtypeIterator.hasNext(SubtypeIterator.java:28)
	at org.jenkinsci.plugins.structs.SymbolLookup.findDescriptor(SymbolLookup.java:143)
	at …
```

which is just noise. `ExtensionList` knows to ignore this registration, but the `@Symbol` index does not go through that code path.

Amends #4.