### PR TITLE
Remove `junit-bom` from managed dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,18 +34,6 @@
     <gitHubRepo>jenkinsci/lib-${project.artifactId}</gitHubRepo>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>5.9.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.kohsuke.metainf-services</groupId>


### PR DESCRIPTION
This is now part of the parent POM.